### PR TITLE
サイトマップ（sitemap.xml）の修正と Search Console 対応

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://yamamu-games.github.io/</loc>
     <lastmod>2025-10-09</lastmod>


### PR DESCRIPTION
Google Search Console でサイトマップが読み込めない問題を修正しました。

### 修正内容
- sitemap.xml の xmlns を正しい形式（http://～）に修正

### 目的
- Search Console でのサイトマップ登録エラー解消
- 検索インデックスの正確化と SEO 改善
