### PR TITLE
Prevent cached news JSON responses

### DIFF
--- a/script.js
+++ b/script.js
@@ -243,9 +243,15 @@ document.addEventListener("DOMContentLoaded", () => {
     // 言語を判定（<html lang="xx"> から取得）
     const lang = document.documentElement.lang || "ja";
     const newsFile = lang === "en" ? "/public/news_en.json" : "/public/news.json";
+    const newsUrl = `${newsFile}?v=${Date.now()}`;
 
-    fetch(newsFile)
-      .then(res => res.json())
+    fetch(newsUrl, { cache: "no-store" })
+      .then(res => {
+        if (!res.ok) {
+          throw new Error(`Failed to fetch news: ${res.status}`);
+        }
+        return res.json();
+      })
       .then(data => {
         data.forEach(item => {
           const article = document.createElement("article");


### PR DESCRIPTION
## Summary
- ニュースJSON取得時にキャッシュされた古いレスポンスが使われないように修正
- JSON取得失敗時に HTTP エラーも検知できるように改善

## Changes
- `script.js` のニュースJSON URLにタイムスタンプのクエリパラメータを付与
- `fetch` に `cache: "no-store"` を指定
- `res.ok` を確認し、失敗時はエラーとして扱うように変更

## Verification
- `git diff --check` 済み